### PR TITLE
Update dockerfile and compose file for goes

### DIFF
--- a/goestools/Dockerfile
+++ b/goestools/Dockerfile
@@ -1,29 +1,18 @@
-FROM bitnami/minideb:latest
+FROM alpine AS base
 
-RUN apt update && apt dist-upgrade -y &&  apt install -y git build-essential cmake libusb-1.0-0-dev libopencv-dev libproj-dev
-
-
-RUN git clone https://github.com/steve-m/librtlsdr.git /opt/librtlsdr 
-RUN mkdir /opt/librtlsdr/build
-WORKDIR /opt/librtlsdr/build
-RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DINSTALL_UDEV_RULES=ON ..
-RUN make -j2 install
-
-# load udev rules and blacklist the DVB driver shipped with the OS
-RUN cp ../rtl-sdr.rules /etc/udev/rules.d/
-RUN ldconfig
-RUN mkdir -p /etc/modprobe.d
-RUN echo 'blacklist dvb_usb_rtl28xxu' | tee --append /etc/modprobe.d/blacklist-dvb_usb_rtl28xxu.conf
+RUN apk add --no-cache opencv-dev zlib && rm -rf /var/cache/apk/*
 
 
-RUN git clone https://github.com/pietern/goestools.git /opt/goestools
-WORKDIR /opt/goestools
-RUN git submodule init
-RUN git submodule update --recursive
-RUN mkdir /opt/goestools/build
-WORKDIR /opt/goestools/build
-RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
+FROM base AS build
 
-# this will take a while on a raspberry pi
-RUN make -j2 install 
-WORKDIR /
+RUN apk add --no-cache cmake build-base && rm -rf /var/cache/apk/*
+
+COPY ./goestools /goestools
+WORKDIR /goestools/build
+
+RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && make -j2 install 
+
+FROM base 
+
+COPY --from=build /usr/share/goestools /usr/share/goestools
+COPY --from=build /usr/bin/goes* /usr/bin/

--- a/goestools/Makefile
+++ b/goestools/Makefile
@@ -1,0 +1,16 @@
+build:
+	docker build -t goestools .
+
+fresh: pull build
+
+clean:
+	rm -rf goestools
+
+pull: clean
+	git clone https://github.com/pietern/goestools.git
+	cd goestools; \
+	git submodule init; \
+	git submodule update --recursive; \
+	mkdir build
+
+

--- a/goestools/docker-compose.yaml
+++ b/goestools/docker-compose.yaml
@@ -1,37 +1,19 @@
 services:
-  goesrecv:
-    container_name: goestools-goesrecv
-    image: goestools
-    hostname: goesrecv
-    expose:
-       - 5004
-    devices:
-       - /dev/bus/usb/001/004:/dev/bus/usb/001/004 
-    volumes:
-       - ./goesrecv.conf:/opt/goesrecv.conf
-    command:
-       - 'goesrecv'
-       - '-v' 
-       - '-i' 
-       - '1' 
-       - '-c' 
-       - '/opt/goesrecv.conf' 
-
   goesproc:
     container_name: goestools-goesproc
     image: goestools
     volumes:
-       - /mnt/data/goes:/data
+      - /mnt/data/goes:/data
     command:
-       - 'goesproc'
-       - '-c'
-       - '/usr/share/goestools/goesproc-goesr.conf'
-       - '-m'
-       - 'packet' 
-       - '--subscribe' 
-       - 'tcp://goesrecv:5004'
-       - '--out' 
-       - '/data'
-    depends_on:
-       - goesrecv
+      - 'goesproc'
+      - '-c'
+      - '/usr/share/goestools/goesproc-goesr.conf'
+      - '-m'
+      - 'packet' 
+      - '--subscribe' 
+      - 'tcp://host.docker.internal:5004'
+      - '--out' 
+      - '/data'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
- goesrecv seems to work alright in docker when drivers are blacklisted on the host, but can't figure out how to make it work without modifying the host system. So scrapping the idea of running goesrecv in docker, isntead plan to run on bare-metal
- attempted to make the docker image smaller, but the apk install opencv-dev makes the image yuge. Ideally that could be moved to the build step and copy over required libs/includes but can't figure out how to identify what is actually needed ...